### PR TITLE
Updated the call of `juice` module to put styles inline in the code

### DIFF
--- a/lib/server/transformers/styles.js
+++ b/lib/server/transformers/styles.js
@@ -47,7 +47,7 @@ void function () {
       if (err)
         return cb(err);
       html = $orHtml.html ? $orHtml.html() : $orHtml;
-      return juice.juiceContent(html, {
+      return juice(html, {
         extraCss: css,
         url: 'file://' + dir
       }, function (err, html) {

--- a/src/server/transformers/styles.coffee
+++ b/src/server/transformers/styles.coffee
@@ -42,7 +42,7 @@ module.exports = ($orHtml, templateName, options, cb) ->
   withStyles "#{dir}/style.styl", (err, css) ->
     return cb(err) if err
     html = if $orHtml.html then $orHtml.html() else $orHtml
-    juice.juiceContent html, extraCss: css, url: "file://#{dir}", (err, html) ->
+    juice html, extraCss: css, url: "file://#{dir}", (err, html) ->
       return cb(err) if err
       cb null, cheerio.load(html)
 


### PR DESCRIPTION
Fixed the call of `juice` module who exports a method instead of call `juice.juiceContent`
the call now is `juice([[args, ...]])` the first argument is the css style